### PR TITLE
Prog 78 validierung excel file reader

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,7 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="938e4817-0387-47e8-95b5-07acc00b3c4f" name="Changes" comment="added excel file reader" />
+    <list default="true" id="938e4817-0387-47e8-95b5-07acc00b3c4f" name="Changes" comment="added excel file reader">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -25,7 +28,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="development" />
+        <entry key="$PROJECT_DIR$" value="PROG-57-excel-file-reader" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -58,26 +61,26 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_ADD_EXTERNAL_FILES": "true",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "git-widget-placeholder": "PROG-77-TestingAndLinting",
-    "ignore.virus.scanning.warn.message": "true",
-    "last_opened_file_path": "C:/workspace/PP2023/pp-2023/src/app/components",
-    "list.type.of.created.stylesheet": "SCSS",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "ts.external.directory.path": "/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-impl/jsLanguageServicesImpl/external",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_ADD_EXTERNAL_FILES&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;fixfilereader&quot;,
+    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/workspace/PP2023/pp-2023/src/app/components&quot;,
+    &quot;list.type.of.created.stylesheet&quot;: &quot;SCSS&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-impl/jsLanguageServicesImpl/external&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\workspace\PP2023\pp-2023\src\app\components" />
@@ -128,6 +131,8 @@
       <workItem from="1696695180172" duration="721000" />
       <workItem from="1696762489654" duration="7106000" />
       <workItem from="1696842650060" duration="1727000" />
+      <workItem from="1697112818433" duration="688000" />
+      <workItem from="1697183487426" duration="1177000" />
     </task>
     <task id="LOCAL-00001" summary="add kMeans test algorithm to the repository">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="938e4817-0387-47e8-95b5-07acc00b3c4f" name="Changes" comment="added excel file reader">
+    <list default="true" id="938e4817-0387-47e8-95b5-07acc00b3c4f" name="Changes" comment="fixed reading csv-files">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pp-2023/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/package-lock.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pp-2023/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pp-2023/src/app/page.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/page.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -49,6 +48,9 @@
       </UrlAndAccount>
     </option>
   </component>
+  <component name="KubernetesApiProvider"><![CDATA[{
+  "isMigrated": true
+}]]></component>
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
   </component>
@@ -281,7 +283,15 @@
       <option name="project" value="LOCAL" />
       <updated>1697196638290</updated>
     </task>
-    <option name="localTasksCounter" value="19" />
+    <task id="LOCAL-00019" summary="fixed reading csv-files">
+      <option name="closed" value="true" />
+      <created>1697199222659</created>
+      <option name="number" value="00019" />
+      <option name="presentableId" value="LOCAL-00019" />
+      <option name="project" value="LOCAL" />
+      <updated>1697199222659</updated>
+    </task>
+    <option name="localTasksCounter" value="20" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -318,6 +328,7 @@
     <MESSAGE value="impement kmeans" />
     <MESSAGE value="remove kmeans src-folder" />
     <MESSAGE value="added excel file reader" />
-    <option name="LAST_COMMIT_MESSAGE" value="added excel file reader" />
+    <MESSAGE value="fixed reading csv-files" />
+    <option name="LAST_COMMIT_MESSAGE" value="fixed reading csv-files" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,7 @@
   <component name="ChangeListManager">
     <list default="true" id="938e4817-0387-47e8-95b5-07acc00b3c4f" name="Changes" comment="fixed reading csv-files">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pp-2023/src/app/page.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/page.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pp-2023/src/app/kmeans/calculateButton.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/kmeans/calculateButton.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -291,7 +291,15 @@
       <option name="project" value="LOCAL" />
       <updated>1697199222659</updated>
     </task>
-    <option name="localTasksCounter" value="20" />
+    <task id="LOCAL-00020" summary="fixed reading csv-files">
+      <option name="closed" value="true" />
+      <created>1697205031709</created>
+      <option name="number" value="00020" />
+      <option name="presentableId" value="LOCAL-00020" />
+      <option name="project" value="LOCAL" />
+      <updated>1697205031709</updated>
+    </task>
+    <option name="localTasksCounter" value="21" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="938e4817-0387-47e8-95b5-07acc00b3c4f" name="Changes" comment="added excel file reader">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pp-2023/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pp-2023/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/package.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -61,26 +63,26 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;ASKED_ADD_EXTERNAL_FILES&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
-    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;fixfilereader&quot;,
-    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/workspace/PP2023/pp-2023/src/app/components&quot;,
-    &quot;list.type.of.created.stylesheet&quot;: &quot;SCSS&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-impl/jsLanguageServicesImpl/external&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "ASKED_ADD_EXTERNAL_FILES": "true",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "PROG-78-ValidierungExcelFileReader",
+    "ignore.virus.scanning.warn.message": "true",
+    "last_opened_file_path": "C:/workspace/PP2023/pp-2023/src/app/components",
+    "list.type.of.created.stylesheet": "SCSS",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ts.external.directory.path": "/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-impl/jsLanguageServicesImpl/external",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\workspace\PP2023\pp-2023\src\app\components" />
@@ -100,6 +102,7 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Node.js.page.js" />
         <item itemvalue="Node.js.page.js" />
         <item itemvalue="Node.js.page.js" />
       </list>
@@ -270,7 +273,15 @@
       <option name="project" value="LOCAL" />
       <updated>1697042159437</updated>
     </task>
-    <option name="localTasksCounter" value="18" />
+    <task id="LOCAL-00018" summary="added excel file reader">
+      <option name="closed" value="true" />
+      <created>1697196638290</created>
+      <option name="number" value="00018" />
+      <option name="presentableId" value="LOCAL-00018" />
+      <option name="project" value="LOCAL" />
+      <updated>1697196638290</updated>
+    </task>
+    <option name="localTasksCounter" value="19" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">

--- a/pp-2023/src/app/page.js
+++ b/pp-2023/src/app/page.js
@@ -10,6 +10,7 @@ import {HandleDynamicGeneratedInputFieldsProvider} from './kmeans/create-save-ma
 import ScatterChart from './kmeans/scatter-chart';
 import {CreateLocalRemoteButton} from "./kmeans/local-remote-button";
 import './globals.css'
+import {checkFileFormat} from "./utils/excelfilereader";
 
 export default function Home() {
 
@@ -31,7 +32,7 @@ export default function Home() {
                                 <section
                                     className='row-gap-3 justify-content-between align-items-center mb-5'>
                                     <div className='file-input'>
-                                        <input className="card-style form-control form-control-lg" type="file" id="excelFileInput"/>
+                                        <input onChange={checkFileFormat} accept={'.xlsx,.csv'} className="card-style form-control form-control-lg" type="file" id="excelFileInput" />
                                     </div>
                                     <CreateLocalRemoteButton localRemoteButton={localRemoteButton} setLocalRemoteButton={setLocalRemoteButton} />
                                 </section>

--- a/pp-2023/src/app/utils/excelfilereader.js
+++ b/pp-2023/src/app/utils/excelfilereader.js
@@ -69,13 +69,28 @@ export const calculateExcel = async () => {
 
                 rows.forEach((row) => {
 
+                    // Dieser Abschnitt ist temporär und säubert die Eingaben bei CSV-Dateien. Später soll das ganze per RegEx geschehen
                     if (row.includes(";")) {
                         const columns = row.replace('\r', '').split(';');
-                        csvData.push(columns);
+                        let filteredColumn = columns.filter(element => element !== "").map(str => parseFloat(str.replace(',', '.')));
+                        if (filteredColumn.length === 0) {
+                            // Array löschen
+                            filteredColumn = null; // Oder myArray = [] für ein leeres Array
+                        }
+                        else {
+                            csvData.push(filteredColumn);
+                        }
                     }
                     else {
                         const columns = row.replace('\r', '').split(',');
-                        csvData.push(columns);
+                        let filteredColumn = columns.filter(element => element !== "").map(str => parseFloat(str.replace(',', '.')));
+                        if (filteredColumn.length === 0) {
+                            // Array löschen
+                            filteredColumn = null; // Oder myArray = [] für ein leeres Array
+                        }
+                        else {
+                            csvData.push(filteredColumn);
+                        }
                     }
                 });
 

--- a/pp-2023/src/app/utils/excelfilereader.js
+++ b/pp-2023/src/app/utils/excelfilereader.js
@@ -8,17 +8,22 @@ export const returnExcel = () => {
 
 export const calculateExcel = async () => {
     const file = returnExcel();
-    console.log(file)
+    console.log(file);
     if (file) {
         const reader = new FileReader();
 
         const data = await new Promise((resolve) => {
             reader.onload = () => {
                 const arrayBuffer = reader.result;
-                const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+                const text = new TextDecoder().decode(arrayBuffer);
+                // Ersetze Kommas durch Punkte für Dezimalstellen
+                const modifiedText = text.replace(/,/g, '.');
+                const modifiedArrayBuffer = new TextEncoder().encode(modifiedText);
+                const workbook = XLSX.read(modifiedArrayBuffer, { type: 'array' });
                 const sheetName = workbook.SheetNames[0];
                 const sheet = workbook.Sheets[sheetName];
                 const jsonData = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+                console.log(jsonData);
                 resolve(jsonData);
             };
 

--- a/pp-2023/src/app/utils/excelfilereader.js
+++ b/pp-2023/src/app/utils/excelfilereader.js
@@ -1,5 +1,15 @@
 import * as XLSX from "xlsx";
 
+function isCSVFile(file) {
+    const fileName = file.name;
+    return fileName.toLowerCase().endsWith('.csv');
+}
+
+function isXLSXFile(file) {
+    const fileName = file.name;
+    return fileName.toLowerCase().endsWith('.xlsx');
+}
+
 export const returnExcel = () => {
     const fileInput = document.getElementById('excelFileInput');
     const file = fileInput.files[0];
@@ -9,7 +19,7 @@ export const returnExcel = () => {
 export const calculateExcel = async () => {
     const file = returnExcel();
     console.log(file)
-    if (file) {
+    if (isXLSXFile(file)){
         const reader = new FileReader();
 
         const data = await new Promise((resolve) => {
@@ -28,10 +38,44 @@ export const calculateExcel = async () => {
 
             reader.readAsArrayBuffer(file);
         });
-        return data;
+        return (data);
+    }
+    else if (isCSVFile(file)){
+        const reader = new FileReader();
 
-    } else {
-        alert('Bitte wähle eine Excel-Datei aus.');
+        const data = await new Promise((resolve) => {
+            reader.onload = () => {
+                const text = reader.result;
+                const rows = text.split('\n');
+                const csvData = [];
+
+                rows.forEach((row) => {
+
+                    if (row.includes(";")) {
+                        const columns = row.replace('\r', '').split(';');
+                        csvData.push(columns);
+                    }
+                    else {
+                        const columns = row.replace('\r', '').split(',');
+                        csvData.push(columns);
+                    }
+                });
+
+                console.log(csvData);
+                resolve(csvData);
+            };
+
+            reader.onerror = () => {
+                console.error('Fehler beim Lesen der Datei');
+            };
+
+            reader.readAsText(file);
+        });
+
+        return (data);
+    }
+    else {
+        alert('Bitte wähle eine .xlsx oder .csv Datei aus.');
         return null; // Fehlerfall: null zurückgeben
     }
 }

--- a/pp-2023/src/app/utils/excelfilereader.js
+++ b/pp-2023/src/app/utils/excelfilereader.js
@@ -8,22 +8,17 @@ export const returnExcel = () => {
 
 export const calculateExcel = async () => {
     const file = returnExcel();
-    console.log(file);
+    console.log(file)
     if (file) {
         const reader = new FileReader();
 
         const data = await new Promise((resolve) => {
             reader.onload = () => {
                 const arrayBuffer = reader.result;
-                const text = new TextDecoder().decode(arrayBuffer);
-                // Ersetze Kommas durch Punkte für Dezimalstellen
-                const modifiedText = text.replace(/,/g, '.');
-                const modifiedArrayBuffer = new TextEncoder().encode(modifiedText);
-                const workbook = XLSX.read(modifiedArrayBuffer, { type: 'array' });
+                const workbook = XLSX.read(arrayBuffer, { type: 'array' });
                 const sheetName = workbook.SheetNames[0];
                 const sheet = workbook.Sheets[sheetName];
                 const jsonData = XLSX.utils.sheet_to_json(sheet, { header: 1 });
-                console.log(jsonData);
                 resolve(jsonData);
             };
 

--- a/pp-2023/src/app/utils/excelfilereader.js
+++ b/pp-2023/src/app/utils/excelfilereader.js
@@ -1,21 +1,39 @@
 import * as XLSX from "xlsx";
 
+// überprüft, ob es sich um eine csv Datei handelt
 function isCSVFile(file) {
     const fileName = file.name;
     return fileName.toLowerCase().endsWith('.csv');
 }
 
+// überprüft, ob es sich um eine xlsx Datei handelt
 function isXLSXFile(file) {
     const fileName = file.name;
     return fileName.toLowerCase().endsWith('.xlsx');
 }
 
+// überprüft, ob das richtige Dateiformat übergeben wurde
+export function checkFileFormat(event) {
+    const file = event.target.files[0];
+    const fileInput = document.getElementById('excelFileInput');
+
+    if (file) {
+        if (!(isXLSXFile(file) || isCSVFile(file))) {
+            // Datei ist im falschen Format, geben Sie einen Alert aus.
+            alert("Die ausgewählte Datei hat ein ungültiges Format. Bitte wählen Sie eine xlsx- oder csv-Datei aus.");
+            fileInput.value = "";
+        }
+    }
+}
+
+// gibt die ganze Excel zurück
 export const returnExcel = () => {
     const fileInput = document.getElementById('excelFileInput');
     const file = fileInput.files[0];
     return (file);
 }
 
+// gibt den Inhalt der Excel als zweidimensionales Array zurück
 export const calculateExcel = async () => {
     const file = returnExcel();
     console.log(file)


### PR DESCRIPTION
Dezimalzahlen können jetzt gelesen werden. Allerdings ist das Format immernoch so wie davor als nur die ersten Zwei Spalten können gelesen werden und bilden dann so die Datasets. RegEx ist noch nicht implementiert also nur saubere Zellen mit Float Values. CSV gehen, außer wenn Semikolons in den Zellen vorhanden sind. Überall wo Semikolons sind wird von dem Reader getrennt (wenn ich am Ende noch Zeit habe schau ich mal nach ner Lösung ansonnsten nehmen wir bei CSV als Regel auf das Semikolons nicht ok sind). Kommas und alle anderen Zeichen funktionieren dafür.

Es werden nurnoch xlsx und csv Dateien beim Upload zugelassen ansonnsten kommt ne Fehlermeldung.