### PR TITLE
Prog 98 elbow criteria chart

### DIFF
--- a/pp-2023/src/app/kmeans/elbow-kriteria.js
+++ b/pp-2023/src/app/kmeans/elbow-kriteria.js
@@ -125,6 +125,7 @@ bestKForKMeans, setBestKForKMeans}) => {
          */
         const validInput = validateInputButtonClick(userInput);
         if (validInput !== undefined) {
+            const timeout = 30000;
 
 
             /*


### PR DESCRIPTION
Elbow Criteria kann jetzt im Chart angezeigt werden: sowohl bei lokaler, als auch bei remote Berechnung. 
Außerdem WICHTIG: Ich hatte ausversehen einen Bug in dev reingemerged, wodurch bei lokaler Berechnung immer sofort der Timeout alert kam, das ist jetzt hier wieder gefixt.