### PR TITLE
fixed Unit-Test errors

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,7 @@
   <component name="ChangeListManager">
     <list default="true" id="938e4817-0387-47e8-95b5-07acc00b3c4f" name="Changes" comment="fixed reading csv-files">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/pp-2023/src/app/kmeans/calculateButton.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/kmeans/calculateButton.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/pp-2023/src/app/kmeans/requestAPI.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/kmeans/requestAPI.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" beforeDir="false" afterPath="$PROJECT_DIR$/pp-2023/src/app/utils/excelfilereader.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -29,7 +29,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="PROG-57-excel-file-reader" />
+        <entry key="$PROJECT_DIR$" value="development" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -65,26 +65,26 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_ADD_EXTERNAL_FILES": "true",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "git-widget-placeholder": "PROG-78-FixFileReaderFinal",
-    "ignore.virus.scanning.warn.message": "true",
-    "last_opened_file_path": "C:/workspace/PP2023/pp-2023/src/app/components",
-    "list.type.of.created.stylesheet": "SCSS",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "ts.external.directory.path": "/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-impl/jsLanguageServicesImpl/external",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_ADD_EXTERNAL_FILES&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;PROG-78-FixFileReaderFinal&quot;,
+    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/workspace/PP2023/pp-2023/src/app/components&quot;,
+    &quot;list.type.of.created.stylesheet&quot;: &quot;SCSS&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Applications/IntelliJ IDEA.app/Contents/plugins/javascript-impl/jsLanguageServicesImpl/external&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\workspace\PP2023\pp-2023\src\app\components" />
@@ -104,6 +104,7 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Node.js.page.js" />
         <item itemvalue="Node.js.page.js" />
         <item itemvalue="Node.js.page.js" />
         <item itemvalue="Node.js.page.js" />

--- a/pp-2023/__tests__/requestAPI.test.js
+++ b/pp-2023/__tests__/requestAPI.test.js
@@ -139,7 +139,7 @@ describe('Testen der GetResult-Anfrage ', () => {
         // Dabei wird erst ein Fetch mit processing aufgerufen, um den Timeout zu testen.
         fetch.mockResolvedValueOnce({
             status: 200,
-            json: () => Promise.resolve({ status: 'processing' }),
+            json: () => Promise.resolve({ status: 'Data Preparation' }),
         });
         fetch.mockResolvedValueOnce({
             status: 200,

--- a/pp-2023/src/app/kmeans/calculateButton.js
+++ b/pp-2023/src/app/kmeans/calculateButton.js
@@ -174,7 +174,10 @@ export function HandleCalculateButtonClick(localRemoteButton) {
           /*
                     Übersenden der eingegebenen Datei an das Backend.
                      */
-          const resultPost = await apiPostRequest(kPoints, dataArrayForWorking);
+          const url =
+              "https://kmeans-backend-test-u3yl6y3tyq-ew.a.run.app/kmeans/";
+          const kForUrl = "k=" + kPoints;
+          const resultPost = await apiPostRequest(url, kForUrl, kPoints, dataArrayForWorking);
           /*
                     Hier wird der Status der Task abgefragt. Aktuell wird ein Intervall von 3000 ms berücksichtigt.
                     Der Parameter maxVersuche, gibt dabei an, wie oft ein Request wiederholt werden soll, bis dieser abbricht.

--- a/pp-2023/src/app/kmeans/requestAPI.js
+++ b/pp-2023/src/app/kmeans/requestAPI.js
@@ -39,7 +39,9 @@ export const createFormData = async (KPoints, dataArrayForWorking) => {
         Aufruf von returnExcel und hinzufügen der geladenen Datei einem formData-Objekt.
          */
     const file = await returnExcel();
-    formData.append("file", file, `${file.name}`);
+    if (file !== null) {
+      formData.append("file", file, `${file.name}`);
+    }
   }
 
   return formData;

--- a/pp-2023/src/app/utils/excelfilereader.js
+++ b/pp-2023/src/app/utils/excelfilereader.js
@@ -29,8 +29,12 @@ export function checkFileFormat(event) {
 // gibt die ganze Excel zurück
 export const returnExcel = () => {
     const fileInput = document.getElementById('excelFileInput');
-    const file = fileInput.files[0];
-    return (file);
+
+    if (fileInput) {
+        return fileInput.files[0];
+    } else {
+        return null;
+    }
 }
 
 // gibt den Inhalt der Excel als zweidimensionales Array zurück


### PR DESCRIPTION
Mit den Änderungen treten zwei der Fehler bei den Unit-Tests nicht mehr auf die mit dem API-Post-Request zusammenhängen.

Diese traten auf, da returnexcel keine Datei übergeben hat. Jetzt gibt es null zurück.

Ein Fehler tritt noch auf, da bin ich aber am Ende mit meinem Latein:

 ● Testen der GetResult-Anfrage  › sollte den Status einer Aufgabe abrufen und verarbeiten    